### PR TITLE
Feat/en 1525 optimized concurrent map cache

### DIFF
--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 )
 
+// ShardCount represent the number of shard the map is devided into.
 const ShardCount = 100
 
 // ConcurrentMap is a "thread" safe map of type string:Anything.

--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-const ShardCount = 30
+const ShardCount = 100
 
 // ConcurrentMap is a "thread" safe map of type string:Anything.
 // To avoid lock bottlenecks this map is dived to several (ShardCount) map shards.

--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ShardCount represent the number of shard the map is devided into.
-var ShardCount = 100
+var ShardCount = 32
 
 // ConcurrentMap is a "thread" safe map of type string:Anything.
 // To avoid lock bottlenecks this map is dived to several (ShardCount) map shards.
@@ -352,7 +352,7 @@ func (m ConcurrentMap) MarshalJSON() ([]byte, error) {
 
 // isEvictionOccurred check if the map size overflow the maximum allowed size.
 func (m ConcurrentMap) isEvictionOccurred(shard *ConcurrentMapShared) bool {
-	if len(shard.mapKeys) > shard.maxSize {
+	if len(shard.items) > shard.maxSize {
 		return true
 	}
 	return false
@@ -371,13 +371,12 @@ func (m ConcurrentMap) removeMapKey(key string) {
 	shard := m.GetShard(key)
 
 	if len(shard.mapKeys) > 0 {
-		for i := 0; i < len(shard.mapKeys)-1; i++ {
+		for i := 0; i < len(shard.mapKeys); i++ {
 			// The mutex lock will be called by the method invoker.
 			if string(key) == shard.mapKeys[i] {
 				shard.mapKeys = append(shard.mapKeys[:i], shard.mapKeys[i+1:]...)
 			}
 		}
-		shard.mapKeys = shard.mapKeys[:len(shard.mapKeys)-1]
 	}
 }
 

--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -49,9 +49,6 @@ func (m ConcurrentMap) Set(key string, value interface{}) {
 	// Get map shard.
 	shard := m.GetShard(key)
 	shard.Lock()
-	if m.isEvictionOccurred(shard) {
-		m.removeOldestMapKey(key)
-	}
 	shard.items[key] = value
 	shard.mapKeys = append(shard.mapKeys, key)
 	shard.Unlock()
@@ -85,9 +82,6 @@ func (m ConcurrentMap) SetIfAbsent(key string, value interface{}) bool {
 	// Get map shard.
 	shard := m.GetShard(key)
 	shard.Lock()
-	if m.isEvictionOccurred(shard) {
-		m.removeOldestMapKey(key)
-	}
 	_, ok := shard.items[key]
 	if !ok {
 		shard.items[key] = value

--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -179,16 +179,6 @@ type Tuple struct {
 	Val interface{}
 }
 
-// Iter returns an iterator which could be used in a for range loop.
-//
-// Deprecated: using IterBuffered() will get a better performance.
-func (m ConcurrentMap) Iter() <-chan Tuple {
-	chans := snapshot(m)
-	ch := make(chan Tuple)
-	go fanIn(chans, ch)
-	return ch
-}
-
 // IterBuffered returns a buffered iterator which could be used in a for range loop.
 func (m ConcurrentMap) IterBuffered() <-chan Tuple {
 	chans := snapshot(m)

--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ShardCount represent the number of shard the map is devided into.
-const ShardCount = 100
+var ShardCount = 100
 
 // ConcurrentMap is a "thread" safe map of type string:Anything.
 // To avoid lock bottlenecks this map is dived to several (ShardCount) map shards.
@@ -361,8 +361,10 @@ func (m ConcurrentMap) isEvictionOccurred(key string) bool {
 func (m ConcurrentMap) removeFirstElement(key string) {
 	shard := m.GetShard(key)
 	shard.Lock()
-	copy(shard.mapKeys[0:], shard.mapKeys[1:])
-	shard.mapKeys = shard.mapKeys[:len(shard.mapKeys)-1]
+	if len(shard.mapKeys) > 0 {
+		copy(shard.mapKeys[0:], shard.mapKeys[1:])
+		shard.mapKeys = shard.mapKeys[:len(shard.mapKeys)-1]
+	}
 	shard.Unlock()
 }
 

--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -324,7 +324,7 @@ func (m ConcurrentMap) FindOldest() string {
 		}
 		shard.Unlock()
 	}
-	return keys[0]
+	return keys[len(keys)-1]
 }
 
 // RemoveOldest removes the oldest key from the key slice.
@@ -347,12 +347,7 @@ func (m ConcurrentMap) MarshalJSON() ([]byte, error) {
 
 // isEvictionOccurred check if the map size overflow the maximum allowed size.
 func (m ConcurrentMap) isEvictionOccurred(shard *ConcurrentMapShared) bool {
-	count := 0
-	for i := 0; i < ShardCount; i++ {
-		shard := m[i]
-		count += len(shard.items)
-	}
-	if count > shard.maxSize {
+	if len(shard.items) > shard.maxSize {
 		return true
 	}
 	return false

--- a/concurrent_map_bench_test.go
+++ b/concurrent_map_bench_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 func BenchmarkItems(b *testing.B) {
-	m := New()
+	count := 10000
+	m := New(count)
 
-	// Insert 100 elements.
-	for i := 0; i < 10000; i++ {
+	// Insert 10000 elements.
+	for i := 0; i < count; i++ {
 		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
 	}
 	for i := 0; i < b.N; i++ {
@@ -19,10 +20,11 @@ func BenchmarkItems(b *testing.B) {
 }
 
 func BenchmarkMarshalJson(b *testing.B) {
-	m := New()
+	count := 10000
+	m := New(count)
 
 	// Insert 100 elements.
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < count; i++ {
 		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
 	}
 	for i := 0; i < b.N; i++ {
@@ -40,7 +42,7 @@ func BenchmarkStrconv(b *testing.B) {
 }
 
 func BenchmarkSingleInsertAbsent(b *testing.B) {
-	m := New()
+	m := New(1000)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		m.Set(strconv.Itoa(i), "value")
@@ -56,7 +58,7 @@ func BenchmarkSingleInsertAbsentSyncMap(b *testing.B) {
 }
 
 func BenchmarkSingleInsertPresent(b *testing.B) {
-	m := New()
+	m := New(1000)
 	m.Set("key", "value")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -74,7 +76,7 @@ func BenchmarkSingleInsertPresentSyncMap(b *testing.B) {
 }
 
 func benchmarkMultiInsertDifferent(b *testing.B) {
-	m := New()
+	m := New(1000)
 	finished := make(chan struct{}, b.N)
 	_, set := GetSet(m, finished)
 	b.ResetTimer()
@@ -89,10 +91,7 @@ func benchmarkMultiInsertDifferent(b *testing.B) {
 func BenchmarkMultiInsertDifferentSyncMap(b *testing.B) {
 	var m sync.Map
 	finished := make(chan struct{}, b.N)
-	err, set := GetSetSyncMap(&m, finished)
-	if err != nil {
-		b.FailNow()
-	}
+	_, set := GetSetSyncMap(&m, finished)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		go set(strconv.Itoa(i), "value")
@@ -116,7 +115,7 @@ func BenchmarkMultiInsertDifferent_256_Shard(b *testing.B) {
 }
 
 func BenchmarkMultiInsertSame(b *testing.B) {
-	m := New()
+	m := New(1000)
 	finished := make(chan struct{}, b.N)
 	_, set := GetSet(m, finished)
 	m.Set("key", "value")
@@ -144,7 +143,7 @@ func BenchmarkMultiInsertSameSyncMap(b *testing.B) {
 }
 
 func BenchmarkMultiGetSame(b *testing.B) {
-	m := New()
+	m := New(1000)
 	finished := make(chan struct{}, b.N)
 	get, _ := GetSet(m, finished)
 	m.Set("key", "value")
@@ -172,7 +171,7 @@ func BenchmarkMultiGetSameSyncMap(b *testing.B) {
 }
 
 func benchmarkMultiGetSetDifferent(b *testing.B) {
-	m := New()
+	m := New(1000)
 	finished := make(chan struct{}, 2*b.N)
 	get, set := GetSet(m, finished)
 	m.Set("-1", "value")
@@ -215,7 +214,7 @@ func BenchmarkMultiGetSetDifferent_256_Shard(b *testing.B) {
 }
 
 func benchmarkMultiGetSetBlock(b *testing.B) {
-	m := New()
+	m := New(1000)
 	finished := make(chan struct{}, 2*b.N)
 	get, set := GetSet(m, finished)
 	for i := 0; i < b.N; i++ {
@@ -290,17 +289,18 @@ func GetSetSyncMap(m *sync.Map, finished chan struct{}) (set func(key, value str
 }
 
 func runWithShards(bench func(b *testing.B), b *testing.B, shardsCount int) {
-	oldShardsCount := SHARD_COUNT
-	SHARD_COUNT = shardsCount
+	oldShardsCount := ShardCount
+	ShardCount = shardsCount
 	bench(b)
-	SHARD_COUNT = oldShardsCount
+	ShardCount = oldShardsCount
 }
 
 func BenchmarkKeys(b *testing.B) {
-	m := New()
+	count := 10000
+	m := New(count)
 
-	// Insert 100 elements.
-	for i := 0; i < 10000; i++ {
+	// Insert 10000 elements.
+	for i := 0; i < count; i++ {
 		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
 	}
 	for i := 0; i < b.N; i++ {

--- a/concurrent_map_test.go
+++ b/concurrent_map_test.go
@@ -280,30 +280,6 @@ func TestIsEmpty(t *testing.T) {
 	}
 }
 
-func TestIterator(t *testing.T) {
-	m := New(100)
-
-	// Insert 100 elements.
-	for i := 0; i < 100; i++ {
-		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
-	}
-
-	counter := 0
-	// Iterate over elements.
-	for item := range m.Iter() {
-		val := item.Val
-
-		if val == nil {
-			t.Error("Expecting an object.")
-		}
-		counter++
-	}
-
-	if counter != 100 {
-		t.Error("We should have counted 100 elements.")
-	}
-}
-
 func TestBufferedIterator(t *testing.T) {
 	m := New(100)
 
@@ -564,8 +540,8 @@ func TestKeysWhenRemoving(t *testing.T) {
 
 //
 func TestUnDrainedIter(t *testing.T) {
-	// Insert 100 elements.
-	Total := 100
+	// Insert 200 elements.
+	Total := 200
 	m := New(Total)
 
 	for i := 0; i < Total; i++ {
@@ -573,35 +549,6 @@ func TestUnDrainedIter(t *testing.T) {
 	}
 	counter := 0
 	// Iterate over elements.
-	ch := m.Iter()
-	for item := range ch {
-		val := item.Val
-
-		if val == nil {
-			t.Error("Expecting an object.")
-		}
-		counter++
-		if counter == 42 {
-			break
-		}
-	}
-	for i := Total; i < 2*Total; i++ {
-		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
-	}
-	for item := range ch {
-		val := item.Val
-
-		if val == nil {
-			t.Error("Expecting an object.")
-		}
-		counter++
-	}
-
-	if counter != 100 {
-		t.Error("We should have been right where we stopped")
-	}
-
-	counter = 0
 	for item := range m.IterBuffered() {
 		val := item.Val
 

--- a/concurrent_map_test.go
+++ b/concurrent_map_test.go
@@ -13,7 +13,7 @@ type Animal struct {
 }
 
 func TestMapCreation(t *testing.T) {
-	m := New()
+	m := New(100)
 	if m == nil {
 		t.Error("map is null.")
 	}
@@ -24,7 +24,7 @@ func TestMapCreation(t *testing.T) {
 }
 
 func TestInsert(t *testing.T) {
-	m := New()
+	m := New(100)
 	elephant := Animal{"elephant"}
 	monkey := Animal{"monkey"}
 
@@ -37,7 +37,7 @@ func TestInsert(t *testing.T) {
 }
 
 func TestInsertAbsent(t *testing.T) {
-	m := New()
+	m := New(100)
 	elephant := Animal{"elephant"}
 	monkey := Animal{"monkey"}
 
@@ -48,7 +48,7 @@ func TestInsertAbsent(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	m := New()
+	m := New(100)
 
 	// Get a missing element.
 	val, ok := m.Get("Money")
@@ -83,7 +83,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestHas(t *testing.T) {
-	m := New()
+	m := New(100)
 
 	// Get a missing element.
 	if m.Has("Money") == true {
@@ -99,7 +99,7 @@ func TestHas(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	m := New()
+	m := New(100)
 
 	monkey := Animal{"monkey"}
 	m.Set("monkey", monkey)
@@ -125,7 +125,7 @@ func TestRemove(t *testing.T) {
 }
 
 func TestRemoveCb(t *testing.T) {
-	m := New()
+	m := New(100)
 
 	monkey := Animal{"monkey"}
 	m.Set("monkey", monkey)
@@ -216,7 +216,7 @@ func TestRemoveCb(t *testing.T) {
 }
 
 func TestPop(t *testing.T) {
-	m := New()
+	m := New(100)
 
 	monkey := Animal{"monkey"}
 	m.Set("monkey", monkey)
@@ -256,7 +256,7 @@ func TestPop(t *testing.T) {
 }
 
 func TestCount(t *testing.T) {
-	m := New()
+	m := New(100)
 	for i := 0; i < 100; i++ {
 		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
 	}
@@ -267,7 +267,7 @@ func TestCount(t *testing.T) {
 }
 
 func TestIsEmpty(t *testing.T) {
-	m := New()
+	m := New(100)
 
 	if m.IsEmpty() == false {
 		t.Error("new map should be empty")
@@ -281,7 +281,7 @@ func TestIsEmpty(t *testing.T) {
 }
 
 func TestIterator(t *testing.T) {
-	m := New()
+	m := New(100)
 
 	// Insert 100 elements.
 	for i := 0; i < 100; i++ {
@@ -305,7 +305,7 @@ func TestIterator(t *testing.T) {
 }
 
 func TestBufferedIterator(t *testing.T) {
-	m := New()
+	m := New(100)
 
 	// Insert 100 elements.
 	for i := 0; i < 100; i++ {
@@ -329,7 +329,7 @@ func TestBufferedIterator(t *testing.T) {
 }
 
 func TestIterCb(t *testing.T) {
-	m := New()
+	m := New(100)
 
 	// Insert 100 elements.
 	for i := 0; i < 100; i++ {
@@ -352,7 +352,7 @@ func TestIterCb(t *testing.T) {
 }
 
 func TestItems(t *testing.T) {
-	m := New()
+	m := New(100)
 
 	// Insert 100 elements.
 	for i := 0; i < 100; i++ {
@@ -367,7 +367,7 @@ func TestItems(t *testing.T) {
 }
 
 func TestConcurrent(t *testing.T) {
-	m := New()
+	m := New(100)
 	ch := make(chan int)
 	const iterations = 1000
 	var a [iterations]int
@@ -426,12 +426,12 @@ func TestConcurrent(t *testing.T) {
 }
 
 func TestJsonMarshal(t *testing.T) {
-	SHARD_COUNT = 2
+	ShardCount = 2
 	defer func() {
-		SHARD_COUNT = 32
+		ShardCount = 32
 	}()
 	expected := "{\"a\":1,\"b\":2}"
-	m := New()
+	m := New(100)
 	m.Set("a", 1)
 	m.Set("b", 2)
 	j, err := json.Marshal(m)
@@ -446,7 +446,7 @@ func TestJsonMarshal(t *testing.T) {
 }
 
 func TestKeys(t *testing.T) {
-	m := New()
+	m := New(100)
 
 	// Insert 100 elements.
 	for i := 0; i < 100; i++ {
@@ -464,7 +464,7 @@ func TestMInsert(t *testing.T) {
 		"elephant": Animal{"elephant"},
 		"monkey":   Animal{"monkey"},
 	}
-	m := New()
+	m := New(100)
 	m.MSet(animals)
 
 	if m.Count() != 2 {
@@ -501,7 +501,7 @@ func TestUpsert(t *testing.T) {
 		return append(res, nv)
 	}
 
-	m := New()
+	m := New(100)
 	m.Set("marine", []Animal{dolphin})
 	m.Upsert("marine", whale, cb)
 	m.Upsert("predator", tiger, cb)
@@ -540,10 +540,9 @@ func TestUpsert(t *testing.T) {
 }
 
 func TestKeysWhenRemoving(t *testing.T) {
-	m := New()
-
 	// Insert 100 elements.
 	Total := 100
+	m := New(Total)
 	for i := 0; i < Total; i++ {
 		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
 	}
@@ -565,9 +564,10 @@ func TestKeysWhenRemoving(t *testing.T) {
 
 //
 func TestUnDrainedIter(t *testing.T) {
-	m := New()
 	// Insert 100 elements.
 	Total := 100
+	m := New(Total)
+
 	for i := 0; i < Total; i++ {
 		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
 	}
@@ -617,9 +617,10 @@ func TestUnDrainedIter(t *testing.T) {
 }
 
 func TestUnDrainedIterBuffered(t *testing.T) {
-	m := New()
 	// Insert 100 elements.
 	Total := 100
+	m := New(Total)
+
 	for i := 0; i < Total; i++ {
 		m.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
 	}


### PR DESCRIPTION
Extended the concurrent map cache with eviction scheme.

The insert and remove operation into the key list is adapted to the sharding mechanism implemented in the main thread.

~~TODO: Optimize (replace with a better alternative) the `fnv32` function.~~