### PR TITLE
fix: missing append to map keys array

### DIFF
--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -19,10 +19,10 @@ type valWithIndex struct {
 
 // ConcurrentMapShared is a "thread" safe string to anything map.
 type ConcurrentMapShard struct {
-	maxSize int
-	idxAdd  int
-	mapKeys []string
-	items   map[string]*valWithIndex
+	maxSize      int
+	idxAdd       int
+	mapKeys      []string
+	items        map[string]*valWithIndex
 	sync.RWMutex // Read Write mutex, guards access to internal map.
 }
 
@@ -77,6 +77,7 @@ func (m *ConcurrentMap) Set(key string, value interface{}) {
 		appendKeyToList(key, shard)
 	} else {
 		shard.mapKeys[v.arrayIdx] = ""
+		appendKeyToList(key, shard)
 	}
 
 	shard.Unlock()
@@ -118,7 +119,7 @@ func (m *ConcurrentMap) Upsert(key string, value interface{}, cb UpsertCb) (res 
 	// if key is new add to the map
 	if !ok {
 		appendKeyToList(key, shard)
-	} else {
+	} else if v != nil {
 		shard.mapKeys[v.arrayIdx] = ""
 	}
 
@@ -212,7 +213,9 @@ func (m *ConcurrentMap) RemoveCb(key string, cb RemoveCb) bool {
 	}
 
 	if remove && ok {
-		shard.mapKeys[v.arrayIdx] = ""
+		if v != nil {
+			shard.mapKeys[v.arrayIdx] = ""
+		}
 		delete(shard.items, key)
 	}
 	shard.Unlock()

--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -73,12 +73,12 @@ func (m *ConcurrentMap) Set(key string, value interface{}) {
 		arrayIdx: shard.idxAdd,
 		val:      value,
 	}
-	if !ok {
-		appendKeyToList(key, shard)
-	} else {
+
+	if ok {
 		shard.mapKeys[v.arrayIdx] = ""
-		appendKeyToList(key, shard)
 	}
+
+	appendKeyToList(key, shard)
 
 	shard.Unlock()
 }

--- a/concurrent_map_test.go
+++ b/concurrent_map_test.go
@@ -39,6 +39,21 @@ func TestInsert(t *testing.T) {
 	}
 }
 
+func TestInsertWithDuplicates(t *testing.T) {
+	shardCount := 1
+	m := New(5*shardCount, shardCount)
+	elephant := Animal{"elephant"}
+
+	for i := 0; i < 1000; i++ {
+		m.Set("elephant", elephant)
+		key := fmt.Sprintf("%x", rand.Int63n(1<<60))
+		m.Set(key, Animal{key})
+	}
+	if m.Count() > 5 {
+		t.Error("map should contain no more than 5 elements but contains", m.Count())
+	}
+}
+
 func TestInsertAbsent(t *testing.T) {
 	shardCount := 32
 	m := New(100*shardCount, shardCount)


### PR DESCRIPTION
Duplicated keys also need to be appended, otherwise the map can grow indefinitely.